### PR TITLE
Comments bugfixes

### DIFF
--- a/app/views/commontator/comments/_form.haml
+++ b/app/views/commontator/comments/_form.haml
@@ -4,7 +4,7 @@
 - new_record = comment.new_record?
 - # Optionally, they can also supply the following variables:
 - thread ||= new_record ? comment.thread : nil
-- no_remote ||= false
+- no_remote ||= true
 - config = comment.thread.config
 - if comment.errors.any?
   .error-explanation

--- a/app/views/commontator/comments/_show.haml
+++ b/app/views/commontator/comments/_show.haml
@@ -4,28 +4,37 @@
 - # nested_children or page
 - # show_all
 - thread = comment.thread
-- nested_children ||= begin
-  - children = thread.paginated_comments(page, comment.id, show_all)
-  - thread.nested_comments_for(user, children, show_all)
+- nested_children ||= thread.nested_comments_for(user, children, show_all)
 - creator = comment.creator
 - link = Commontator.commontator_link(creator, main_app)
 - name = Commontator.commontator_name(creator) || ''
+- is_deleted = comment.is_deleted?
 .card
-  .card-body
+  .card-body{class: (is_deleted && 'text-muted em')}
     %strong.author{id: "commontator-comment-#{comment.id}-author"}
       = link.blank? ? name : link_to(name, link)
     %small
       %span.timestamp{id: "commontator-comment-#{comment.id}-created-timestamp"}
         = comment.created_timestamp
       %span.timestamp{id: "commontator-comment-#{comment.id}-updated-timestamp"}
-        - if comment.is_modified?
+        - if is_deleted
+          - deletion_title = comment.editor == creator ? "" : "Deleted by #{comment.editor.name}"
+          %strong{title: deletion_title, data: {toggle: 'tooltip', placement: 'right'}} [deleted]
+        - elsif comment.is_modified?
           %span{title: comment.updated_timestamp, data: {toggle: 'tooltip', placement: 'right'}} ✏️
-    %span.avatar.float-left.mt-2.mr-3.mb-1{id: "commontator-comment-#{comment.id}-avatar"}
-      = Commontator.commontator_avatar(creator, self)
-    %span.votes{id: "commontator-comment-#{comment.id}-votes"}
-      - # render partial: 'commontator/comments/votes', locals: { comment: comment, user: user }
-    .body{id: "commontator-comment-#{comment.id}-body"}
-      = render partial: 'commontator/comments/body', locals: { comment: comment }
+    - unless is_deleted
+      %span.avatar.float-left.mt-2.mr-3.mb-1{id: "commontator-comment-#{comment.id}-avatar"}
+        = Commontator.commontator_avatar(creator, self)
+    - if is_deleted
+      %span.actions
+        .float-right{id: "commontator-comment-#{comment.id}-actions"}
+          .btn-group
+            - if comment.can_be_deleted_by?(user)
+              - del_string = :undelete
+              = link_to t("commontator.comment.actions.#{del_string}"), commontator.polymorphic_path([del_string, comment]), data: is_deleted ? {} : { confirm: t('commontator.comment.actions.confirm_delete') }, method: :put, id: "commontator-comment-#{comment.id}-#{del_string}", class: "#{del_string} btn btn-sm btn-danger", remote: false
+    - else
+      .body{id: "commontator-comment-#{comment.id}-body"}
+        = render partial: 'commontator/comments/body', locals: { comment: comment }
     .clearfix
     .section.bottom{id: "commontator-comment-#{comment.id}-section-bottom"}
     .children{id: "commontator-comment-#{comment.id}-children"}
@@ -35,20 +44,14 @@
         locals: { user: user, nested_comments: nested_children } |
       - if thread.config.comment_order != :l
         .reply{id: "commontator-comment-#{comment.id}-reply"}
-    .pagination{id: "commontator-comment-#{comment.id}-pagination"}
-      .will-paginate{id: "commontator-comment-#{comment.id}-will-paginate"}
-        = will_paginate nested_children, renderer: Commontator::LinkRenderer, name: t('commontator.comment.status.reply_pages'), remote: true, params: { controller: 'commontator/comments',action: 'show', id: comment.id }
-
-
-    %span.actions
-      .float-right{id: "commontator-comment-#{comment.id}-actions"}
-        .btn-group
-          - if comment.can_be_edited_by?(user)
-            = link_to(t('commontator.comment.actions.edit'), commontator.edit_comment_path(comment), id: "commontator-comment-#{comment.id}-edit", class: 'edit btn btn-sm btn-primary', remote: true)
-          - if comment.can_be_deleted_by?(user)
-            - is_deleted = comment.is_deleted?
-            - del_string = is_deleted ? :undelete : :delete
-            = link_to t("commontator.comment.actions.#{del_string}"), commontator.polymorphic_path([del_string, comment]), data: is_deleted ? {} : { confirm: t('commontator.comment.actions.confirm_delete') }, method: :put, id: "commontator-comment-#{comment.id}-#{del_string}", class: "#{del_string} btn btn-sm btn-danger", remote: true
-      - unless comment.is_deleted?
+    - unless is_deleted
+      %span.actions
+        .float-right{id: "commontator-comment-#{comment.id}-actions"}
+          .btn-group
+            - if comment.can_be_edited_by?(user)
+              = link_to(t('commontator.comment.actions.edit'), commontator.edit_comment_path(comment), id: "commontator-comment-#{comment.id}-edit", class: 'edit btn btn-sm btn-primary', remote: true)
+            - if comment.can_be_deleted_by?(user)
+              - del_string = is_deleted ? :undelete : :delete
+              = link_to t("commontator.comment.actions.#{del_string}"), commontator.polymorphic_path([del_string, comment]), data: is_deleted ? {} : { confirm: t('commontator.comment.actions.confirm_delete') }, method: :put, id: "commontator-comment-#{comment.id}-#{del_string}", class: "#{del_string} btn btn-sm btn-danger", remote: false
         .float-left{id: "commontator-comment-#{comment.id}-reply-link"}
           = link_to("Reply", commontator.new_thread_comment_path(thread, comment: { parent_id: comment.id }), remote: true, class: 'btn btn-sm btn-primary') if thread.config.comment_reply_style != :n && !thread.is_closed?

--- a/app/views/commontator/threads/_reply.haml
+++ b/app/views/commontator/threads/_reply.haml
@@ -10,7 +10,7 @@
   - else
     - if @commontator_new_comment.nil?
       .new-comment{id: "commontator-thread-#{thread.id}-new-comment-link"}
-        = link_to t('commontator.comment.actions.new'), commontator.new_thread_comment_path(thread), remote: true, class: 'btn btn-primary m-2'
+        = link_to t('commontator.comment.actions.new'), commontator.new_thread_comment_path(thread), remote: false, class: 'btn btn-primary m-2'
     %div{class: "new-comment#{@commontator_new_comment.nil? ? ' hidden' : ''}", id: "commontator-thread-#{thread.id}-new-comment"}
       - unless @commontator_new_comment.nil?
         = render partial: 'commontator/comments/form', locals: {comment: @commontator_new_comment, thread: thread}

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -235,7 +235,10 @@ Commontator.configure do |config|
   # The maximum number of comments loaded at once for the default setting is:
   # 20 + 20*5 + 20*5*2 == 320
   # Default: [ 20, 5, 2 ]
-  config.comments_per_page = [ 20, 5, 2 ]
+  # [steve] This app isn't intended for extremely high-activity events, so we just set it to
+  #   load all of the comments to an absurd depth. If your threads spiral more than 20 comments deep,
+  #   consider using a fancier program.
+  config.comments_per_page = [ 100 ] * 20
 
   # thread_subscription
   # Type: Symbol


### PR DESCRIPTION
* Allow very deeply nested replies
* Make deleted comments actually look deleted
* Turn off async comment submissions since we're not properly loading comment javascript anyway. Fixes comments not showing up until page gets refreshed.
* Disables some features we're not using (e.g. up/downvotes and nested thread pagination).