### PR TITLE
Show RSVP emails in copypastable list on event page

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -19,7 +19,7 @@ class AttendancesController < ApplicationController
       if current_user
         notice = 'RSVP successful.'
       else
-        notice = "RSVP successful. You can manage your RSVP at #{event_url(@event, guest_guid: @attendance.attendee.guid)}"
+        notice = "RSVP successful. Bookmark this link to change your RSVP later: #{event_url(@event, guest_guid: @attendance.attendee.guid)}"
       end
 
       redirect_to event_path(@event, guest_guid: @attendance.attendee.try(:guid)), notice: notice

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,6 +4,8 @@ class EventsController < ApplicationController
   before_action :set_owned_event, only: [:edit, :update, :destroy]
   before_action :load_prior_addresses, only: [:new, :edit, :create, :update]
 
+  PRELOAD = [:owner, {attendances: :attendee, commontator_thread: :comments, polls: :responses}]
+
   def index
     if params[:user_id]
       @target_user = User.friendly.find(params[:user_id])
@@ -96,12 +98,12 @@ class EventsController < ApplicationController
   private
 
   def set_event
-    @event = Event.friendly.find(params[:id])
+    @event = Event.includes(*EventsController::PRELOAD).friendly.find(params[:id])
   end
 
   # ensures that the event being access is owned by the current user
   def set_owned_event
-    @event = current_user.managed_events.friendly.find(params[:id])
+    @event = current_user.managed_events.includes(**EventsController::PRELOAD).friendly.find(params[:id])
   end
 
   def load_prior_addresses

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,7 +9,6 @@ class Event < ApplicationRecord
   friendly_id :title, use: :slugged
 
   has_many :attendances, dependent: :destroy
-  has_many :attendees, through: :attendances, class_name: 'User'
 
   # photo for header of event, will be thumbnailed for index view
   has_one_attached :photo

--- a/app/views/events/_rsvps.html.haml
+++ b/app/views/events/_rsvps.html.haml
@@ -18,4 +18,9 @@
         - if collection.empty?
           %li.list-group-item
             %small.text-muted Nobody yet!
+        - elsif @event.owned_by?(current_user)
+          %li.list-group-item
+            %div.mb-2
+              %strong Emails
+              = text_area_tag nil, collection.map(&:attendee).pluck(:email).join(",\n"), class: 'form-control'
         = render partial: "attendances/attendance", collection: collection


### PR DESCRIPTION
Also improves guest RSVP alert wording and adds some eager loading to the event page to reduce N+1 queries.