### PR TITLE
Add 'My RSVPed Events' screen to navbar

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :authenticate_user!, except: [:show, :ical, :index]
+  before_action :authenticate_user!, except: [:show, :ical, :index, :attendee_index]
   before_action :set_event, only: [:show, :ical]
   before_action :set_owned_event, only: [:edit, :update, :destroy]
   before_action :load_prior_addresses, only: [:new, :edit, :create, :update]
@@ -9,20 +9,29 @@ class EventsController < ApplicationController
   def index
     if params[:user_id]
       @host = User.friendly.find(params[:user_id])
-    end
-
-    @events = get_events_list_for(@host)
-
-    @current_scope = params[:scope] || "future"
-
-    case @current_scope
-    when "past"
-      @events = @events.where("end_time < ?", Time.current)
+      if current_user && current_user == @host
+        @index_title = t('event.index.self')
+      else
+        @index_title = t('event.index.for_user', name: @host.name)
+      end
     else
-      @events = @events.where("end_time > ?", Time.current)
+      @index_title = t('event.index.public')
     end
 
-    @events = @events.order(end_time: :desc)
+    @events, @current_scope = time_scoped_events_list(get_events_list_for(@host), params[:scope])
+  end
+
+  def attendee_index
+    if @authenticated_user.nil?
+      redirect_to events_url, notice: t('event.index.attending.auth_required')
+      return
+    end
+
+    @index_title = t('event.index.attending.title')
+
+    @events, @current_scope = time_scoped_events_list(@authenticated_user.rsvped_events, params[:scope])
+
+    render :index
   end
 
   def show
@@ -89,6 +98,15 @@ class EventsController < ApplicationController
     events = events.includes(:attendances, :owner)
 
     user_scoped_events_list(events, @authenticated_user)
+  end
+
+  def time_scoped_events_list(events, target_scope)
+    case target_scope
+    when "past"
+      return [events.where("end_time <= ?", Time.current).order(end_time: :desc), "past"]
+    else
+      return [events.where("end_time > ?", Time.current).order(end_time: :desc), "future"]
+    end
   end
 
   # Hides all secret events except ones the user has already RSVPed to.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,8 @@ class User < ApplicationRecord
   has_many :addresses, -> { distinct }, through: :managed_events
   # events the user has rsvped to - some of these may be 'no' rsvps,
   # hence not calling this 'attended_events'
-  has_many :rsvped_events, through: :attendances, class_name: "Event"
   has_many :attendances, as: :attendee, dependent: :destroy
+  has_many :rsvped_events, source: :event, through: :attendances, class_name: "Event"
   has_many :comments, as: :creator, dependent: :destroy
   has_many :edited_comments, as: :editor, class_name: "Comment"
   has_many :poll_responses, as: :respondent, dependent: :destroy

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,23 +1,9 @@
-- if @host
-  - title t('event.index.for_user', name: @host.name)
-- else
-  - title t('event.index.public')
-
+- title @index_title
 %h1.title
-  - if current_user && current_user == @host
-    = t('event.index.self')
-  - else
-    - if @host
-      = t('event.index.for_user', name: @host.name)
-    - else
-      = t('event.index.public')
+  = @index_title
   .btn-group{role: "group", "aria-label" => "event scopes"}
-    - if @host
-      = scope t('event.index.category.upcoming'), user_events_path(@host, scope: :future), :future
-      = scope t('event.index.category.past'), user_events_path(@host, scope: :past), :past
-    - else
-      = scope t('event.index.category.upcoming'), events_path(scope: :future), :future
-      = scope t('event.index.category.past'), events_path(scope: :past), :past
+    = scope t('event.index.category.upcoming'), url_for(scope: :future), :future
+    = scope t('event.index.category.past'), url_for(scope: :past), :past
 - if @events.any?
   - @events.each do |event|
     .row.bg-light.mb-2.py-2

--- a/app/views/partials/_navbar.html.haml
+++ b/app/views/partials/_navbar.html.haml
@@ -24,6 +24,7 @@
             %a.nav-link.dropdown-toggle#attendee-dropdown{href: '#', role: 'button', data: {'bs-toggle': 'dropdown'}, aria: {haspopup: 'true', expanded: 'false'}}= t('navbar.attendee.header')
             .dropdown-menu{aria: {labelledBy: 'attendee-dropdown'}}
               = link_to t('navbar.attendee.public_events'), events_path, class: "dropdown-item"
+              = link_to t('navbar.attendee.rsvped_events'), rsvped_events_path, class: 'dropdown-item'
           %li.nav-item= link_to t('navbar.profile'), edit_user_registration_path, class: "nav-link"
           %li.nav-item= button_to t('navbar.log_out'), destroy_user_session_path, method: :delete, class: "nav-link btn btn-link"
         - else

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -19,6 +19,7 @@ en:
     attendee:
       header: Attendee
       public_events: Public Events
+      rsvped_events: RSVPed Events
     profile: My Profile
     log_out: Log out
     log_in: Log in

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -19,6 +19,7 @@ es:
     attendee:
       header: Invitado
       public_events: Eventos Públicos
+      rsvped_events: Eventos con RSVP
     profile: Mi Perfil
     log_out: Cerrar sessión
     log_in: Iniciar sessión

--- a/config/locales/models/event/en.yml
+++ b/config/locales/models/event/en.yml
@@ -51,6 +51,9 @@ en:
       for_user: "Events from %{name}"
       public: Public Events
       self: Your Events
+      attending:
+        title: Your RSVPed Events
+        auth_required: You need to be logged in to see your RSVP history.
       hosted_by: "Hosted by %{name}"
       category:
         upcoming: Upcoming

--- a/config/locales/models/event/es.yml
+++ b/config/locales/models/event/es.yml
@@ -54,6 +54,9 @@ es:
       public: Eventos Públicos
       self: Sus Eventos
       hosted_by: "Hospedado por %{name}"
+      attending:
+        title: Eventos con su RSVP
+        auth_required: Se necesita estar autenticado para ver su historia de RSVP.
       category:
         upcoming: Próximo
         past: Pasado

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
         get 'ical'
       end
 
+      collection do
+        get 'rsvped', to: 'events#attendee_index'
+      end
+
       resources :comments, only: [:create, :update, :destroy] do
         member do
           put 'undelete'

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,6 +2,36 @@ require 'rails_helper'
 
 describe EventsController do
 
+  describe "GET attendee_index" do
+    it "redirects to the main index when not logged in" do
+      get :attendee_index
+      expect(response).to redirect_to events_path
+    end
+
+    context "logged in" do
+      before do
+        @user = FactoryBot.create(:user)
+        sign_in @user
+        @later_event = FactoryBot.create(:event, start_time: Time.current, end_time: Time.current + 1.day)
+        FactoryBot.create(:attendance, event: @later_event, attendee: @user)
+        @later_event_unrsvped = FactoryBot.create(:event, start_time: Time.current, end_time: Time.current + 1.day)
+        @earlier_event = FactoryBot.create(:event, start_time: Time.current - 25.hours, end_time: Time.current - 1.day)
+        FactoryBot.create(:attendance, event: @earlier_event, attendee: @user)
+        @earlier_event_unrsvped = FactoryBot.create(:event, start_time: Time.current - 25.hours, end_time: Time.current - 1.day)
+      end
+
+      it "shows future events the user has RSVPed to" do
+        get :attendee_index
+        expect(assigns(:events)).to match_array([@later_event])
+      end
+
+      it "shows past events the user has RSVPed to when past scope specified" do
+        get :attendee_index, params: {scope: :past}
+        expect(assigns(:events)).to match_array([@earlier_event])
+      end
+    end
+  end
+
   describe "GET index" do
     before do
       # we make both to test 'wrong user' cases more thoroughly

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
Gives users a way to see all events they've RSVPed to. Not available to guest accounts, since they're not intended to be used across more than one event.