### PR TITLE
Fix 422 when adding and removing +1s in the same update

### DIFF
--- a/app/models/concerns/can_have_plus_ones.rb
+++ b/app/models/concerns/can_have_plus_ones.rb
@@ -4,11 +4,15 @@ module CanHavePlusOnes
   included do
     has_many :plus_ones, class_name: "Attendance", foreign_key: :attendance_id, dependent: :destroy
     accepts_nested_attributes_for :plus_ones, allow_destroy: true
-    
+
     validates_each :plus_ones do |attendance, attr, value|
-      if !attendance.event.allows_plus_ones? && attendance.plus_ones.any?
+      # Nested attributes keep records marked for destruction in the association until
+      # save; the UI can destroy and add in one submit, so only count active +1s.
+      active_plus_ones = attendance.plus_ones.reject(&:marked_for_destruction?)
+
+      if !attendance.event.allows_plus_ones? && active_plus_ones.any?
         attendance.errors.add(:base, :plus_ones_not_allowed)
-      elsif attendance.event.has_plus_one_limit? && attendance.plus_ones.length > attendance.event.plus_one_max
+      elsif attendance.event.has_plus_one_limit? && active_plus_ones.length > attendance.event.plus_one_max
         attendance.errors.add(:base, :beyond_plus_one_limit)
       end
     end

--- a/spec/controllers/attendances_controller_spec.rb
+++ b/spec/controllers/attendances_controller_spec.rb
@@ -214,6 +214,40 @@ describe AttendancesController do
         expect(response).to redirect_to(event_path(@event))
         expect(@attendance.reload.rsvp_status).to eq 'Maybe'
       end
+
+      # Mirrors DynamicListManager form data: mark persisted +1 for destroy, append a new +1 row.
+      it "allows removing and adding a plus-one in the same update at the limit" do
+        @event.update!(plus_one_max: 1)
+        existing = FactoryBot.create(:guest_attendance, parent_attendance: @attendance, event: @event)
+
+        patch :update, params: {
+          id: @attendance.id,
+          attendance: {
+            rsvp_status: "Yes",
+            plus_ones_attributes: {
+              "0" => {
+                id: existing.id,
+                event_id: @event.id,
+                _destroy: "1",
+                attendee_attributes: { id: existing.attendee.id },
+              },
+              "1784725840912" => {
+                event_id: @event.id,
+                _destroy: "0",
+                attendee_attributes: {
+                  name: "New Plus One",
+                  email: "new-plus-one@example.com",
+                },
+              },
+            },
+          },
+        }
+
+        expect(response).to redirect_to(event_path(@event))
+        expect(@attendance.reload.plus_ones.count).to eq 1
+        expect(@attendance.plus_ones.first.attendee.name).to eq "New Plus One"
+        expect(Attendance.find_by(id: existing.id)).to be_nil
+      end
     end
   end
 

--- a/spec/models/attendance_spec.rb
+++ b/spec/models/attendance_spec.rb
@@ -56,6 +56,30 @@ describe Attendance do
     expect(beyond_limit_attendance).not_to be_valid
   end
 
+  it "allows replacing a plus one in the same update when at the limit" do
+    event = FactoryBot.create(:event, plus_one_max: 1)
+    attendance = FactoryBot.create(:attendance, event: event)
+    existing = FactoryBot.create(:guest_attendance, parent_attendance: attendance, event: event)
+    attendance.reload
+
+    result = attendance.update(
+      plus_ones_attributes: {
+        "0" => { id: existing.id, _destroy: "1" },
+        "1" => {
+          event_id: event.id,
+          rsvp_status: "Yes",
+          attendee_type: "Guest",
+          attendee_attributes: { name: "New Plus One", email: "new-plus-one@example.com" },
+        },
+      }
+    )
+
+    expect(result).to be true
+    expect(attendance.reload.plus_ones.count).to eq 1
+    expect(attendance.plus_ones.first.attendee.name).to eq "New Plus One"
+    expect(Attendance.find_by(id: existing.id)).to be_nil
+  end
+
   it "rejects plus ones for events with plus-ones disabled" do
     event = FactoryBot.create(:event, plus_one_max: 0)
     attendance = FactoryBot.build(:attendance, event: event, plus_ones: [FactoryBot.create(:guest_attendance, event: event)])


### PR DESCRIPTION
## Summary
- Fixes [#164](https://github.com/ThePletch/shay-parties/issues/164): replacing a +1 (destroy existing + add new) in one RSVP submit no longer returns 422 when at the event's plus-one limit.
- Plus-one limit validation now ignores association members marked for destruction, matching DynamicListManager form behavior.
- Adds model and controller regression coverage for the list-manager-shaped payload.

## Test plan
- [ ] RSVP to an event with `plus_one_max: 1` and an existing +1
- [ ] Mark the existing +1 for removal, add a new +1, submit RSVP — expect success (not 422)
- [ ] Confirm still cannot submit more active +1s than the limit without removing one
- [ ] `bundle exec rspec spec/models/attendance_spec.rb spec/controllers/attendances_controller_spec.rb`
